### PR TITLE
Add support for blank passwords

### DIFF
--- a/packages/libraries/main/src/scoring.ts
+++ b/packages/libraries/main/src/scoring.ts
@@ -102,13 +102,15 @@ const scoringHelper = {
     let sequenceLength = 0
     let g = 2e308
     const temp = this.optimal.g[k]
-    Object.keys(this.optimal.g[k]).forEach((candidateSequenceLength) => {
-      const candidateMetricMatch = temp[candidateSequenceLength]
-      if (candidateMetricMatch < g) {
-        sequenceLength = parseInt(candidateSequenceLength, 10)
-        g = candidateMetricMatch
-      }
-    })
+    if (temp) { // safety check for empty passwords
+      Object.keys(temp).forEach((candidateSequenceLength) => {
+        const candidateMetricMatch = temp[candidateSequenceLength]
+        if (candidateMetricMatch < g) {
+          sequenceLength = parseInt(candidateSequenceLength, 10)
+          g = candidateMetricMatch
+        }
+      })
+    }
     while (k >= 0) {
       const match: MatchExtended = this.optimal.m[k][sequenceLength]
       optimalMatchSequence.unshift(match)

--- a/packages/libraries/main/test/helper/passwordTests.ts
+++ b/packages/libraries/main/test/helper/passwordTests.ts
@@ -867,4 +867,31 @@ export default [
       ],
     },
   },
+  {
+    calcTime: 0,
+    password: '',
+    guesses: 1,
+    guessesLog10: 0,
+    sequence: [],
+    crackTimesSeconds: {
+      onlineThrottling100PerHour: 36,
+      onlineNoThrottling10PerSecond: 0.1,
+      offlineSlowHashing1e4PerSecond: 0.0001,
+      offlineFastHashing1e10PerSecond: 1e-10
+    },
+    crackTimesDisplay: {
+      onlineThrottling100PerHour: '36 seconds',
+      onlineNoThrottling10PerSecond: 'less than a second',
+      offlineSlowHashing1e4PerSecond: 'less than a second',
+      offlineFastHashing1e10PerSecond: 'less than a second'
+    },
+    score: 0,
+    feedback: {
+      warning: '',
+      suggestions: [
+        'Use multiple words, but avoid common phrases.',
+        'You can create strong passwords without using symbols, numbers, or uppercase letters.'
+      ]
+    }
+  },
 ]


### PR DESCRIPTION
The "old" version of zxcvbn supported empty strings, but there was a line in scoring.ts that got tripped up by the empty string. I patched it up and added a test!