### PR TITLE
Separate async/sync into two functions (breaking-change)

### DIFF
--- a/docs/guide/matcher/README.md
+++ b/docs/guide/matcher/README.md
@@ -1,7 +1,7 @@
 # Matcher
 
 There are multiple build in matchers to identify the strength of a password. All build in matchers are sync but custom matcher have the possibility to be async.
-Therefor if you are using an async custom matcher the `zxcvbn` core function returns a promise which resolves into the `ZxcvbnResult`
+Therefor if you are using an async custom matcher you need to the `zxcvbnAsync` function.
 
 ## bruteforce
 

--- a/packages/libraries/main/src/index.ts
+++ b/packages/libraries/main/src/index.ts
@@ -32,22 +32,35 @@ const createReturnValue = (
   }
 }
 
-export const zxcvbn = (password: string, userInputs?: (string | number)[]) => {
+const main = (password: string, userInputs?: (string | number)[]) => {
   if (userInputs) {
     Options.extendUserInputsDictionary(userInputs)
   }
 
   const matching = new Matching()
 
-  const start = time()
+  return matching.match(password)
+}
 
-  const matches = matching.match(password)
+export const zxcvbn = (password: string, userInputs?: (string | number)[]) => {
+  const start = time()
+  const matches = main(password, userInputs)
 
   if (matches instanceof Promise) {
-    return matches.then((resolvedMatches) => {
-      return createReturnValue(resolvedMatches, password, start)
-    })
+    throw new Error(
+      'You are using a Promised matcher, please use `zxcvbnAsync` for it.',
+    )
   }
+  return createReturnValue(matches, password, start)
+}
+
+export const zxcvbnAsync = async (
+  password: string,
+  userInputs?: (string | number)[],
+): Promise<ZxcvbnResult> => {
+  const start = time()
+  const matches = await main(password, userInputs)
+
   return createReturnValue(matches, password, start)
 }
 

--- a/packages/libraries/main/test/asyncMatcher.spec.ts
+++ b/packages/libraries/main/test/asyncMatcher.spec.ts
@@ -1,6 +1,6 @@
 import zxcvbnCommonPackage from '../../../languages/common/src'
 import zxcvbnEnPackage from '../../../languages/en/src'
-import { zxcvbn, ZxcvbnOptions } from '../src'
+import { zxcvbn, zxcvbnAsync, ZxcvbnOptions } from '../src'
 import { Matcher, MatchExtended } from '../src/types'
 
 ZxcvbnOptions.setOptions({
@@ -45,9 +45,18 @@ ZxcvbnOptions.addMatcher('minLength', asyncMatcher)
 
 describe('asyncMatcher', () => {
   it('should use async matcher as a promise', async () => {
-    let result = zxcvbn('ep8fkw8ds')
-    expect(result instanceof Promise).toBe(true)
-    result = await result
+    const promiseResult = zxcvbnAsync('ep8fkw8ds')
+    expect(promiseResult instanceof Promise).toBe(true)
+
+    const result = await promiseResult
     expect(result.calcTime).toBeDefined()
+  })
+
+  it('should throw an error for wrong function usage', async () => {
+    expect(() => {
+      zxcvbn('ep8fkw8ds')
+    }).toThrowError(
+      'You are using a Promised matcher, please use `zxcvbnAsync` for it.',
+    )
   })
 })

--- a/packages/libraries/main/test/customMatcher.spec.ts
+++ b/packages/libraries/main/test/customMatcher.spec.ts
@@ -1,7 +1,7 @@
 import zxcvbnCommonPackage from '../../../languages/common/src'
 import zxcvbnEnPackage from '../../../languages/en/src'
 import { zxcvbn, ZxcvbnOptions } from '../src'
-import { Match, Matcher, ZxcvbnResult } from '../src/types'
+import { Match, Matcher } from '../src/types'
 import { sorted } from '../src/helper'
 
 ZxcvbnOptions.setOptions({

--- a/packages/libraries/main/test/customMatcher.spec.ts
+++ b/packages/libraries/main/test/customMatcher.spec.ts
@@ -45,7 +45,7 @@ ZxcvbnOptions.addMatcher('minLength', minLengthMatcher)
 
 describe('customMatcher', () => {
   it('should use minLength custom matcher', () => {
-    const result = zxcvbn('ep8fkw8ds') as ZxcvbnResult
+    const result = zxcvbn('ep8fkw8ds')
     expect(result.calcTime).toBeDefined()
     result.calcTime = 0
     expect(result).toEqual({

--- a/packages/libraries/main/test/main.spec.ts
+++ b/packages/libraries/main/test/main.spec.ts
@@ -17,7 +17,7 @@ describe('main', () => {
   })
 
   it('should check without userInputs', () => {
-    const result = zxcvbn('test') as ZxcvbnResult
+    const result = zxcvbn('test')
     expect(result.calcTime).toBeDefined()
     result.calcTime = 0
     expect(result).toEqual({
@@ -68,7 +68,7 @@ describe('main', () => {
       // @ts-ignore
       dictionary: { userInputs: ['test', 12, true, []] },
     })
-    const result = zxcvbn('test') as ZxcvbnResult
+    const result = zxcvbn('test')
     result.calcTime = 0
     expect(result).toEqual({
       crackTimesDisplay: {
@@ -114,7 +114,7 @@ describe('main', () => {
   })
 
   it('should check with userInputs on the fly', () => {
-    const result = zxcvbn('onTheFly', ['onTheFly']) as ZxcvbnResult
+    const result = zxcvbn('onTheFly', ['onTheFly'])
     result.calcTime = 0
     expect(result).toEqual({
       calcTime: 0,
@@ -168,7 +168,7 @@ describe('main', () => {
             ...zxcvbnEnPackage.dictionary,
           },
         })
-        const result = zxcvbn(data.password) as ZxcvbnResult
+        const result = zxcvbn(data.password)
         result.calcTime = 0
         expect(JSON.stringify(result)).toEqual(JSON.stringify(data))
       })

--- a/packages/libraries/main/test/main.spec.ts
+++ b/packages/libraries/main/test/main.spec.ts
@@ -2,7 +2,6 @@ import zxcvbnCommonPackage from '../../../languages/common/src'
 import zxcvbnEnPackage from '../../../languages/en/src'
 import { zxcvbn, ZxcvbnOptions } from '../src'
 import passwordTests from './helper/passwordTests'
-import { ZxcvbnResult } from '../src/types'
 
 describe('main', () => {
   beforeEach(() => {

--- a/packages/libraries/main/test/scoring/guesses/calc.spec.ts
+++ b/packages/libraries/main/test/scoring/guesses/calc.spec.ts
@@ -29,7 +29,7 @@ describe('scoring', () => {
       day: 14,
       // @ts-ignore
       guesses: dateGuesses(match),
-      guessesLog10: 4.205745540942662,
+      guessesLog10: 4.215505378231819,
     })
   })
 })

--- a/packages/libraries/pwned/test/index.spec.ts
+++ b/packages/libraries/pwned/test/index.spec.ts
@@ -1,4 +1,4 @@
-import { zxcvbn, ZxcvbnOptions } from '../../main/src'
+import { zxcvbnAsync, ZxcvbnOptions} from '../../main/src'
 import matcherPwnedFactory from '../src'
 
 const fetch = jest.fn(() => ({
@@ -14,7 +14,7 @@ describe('main', () => {
   })
 
   it('should use pwned matcher', async () => {
-    const result = await zxcvbn('P4$$w0rd')
+    const result = await zxcvbnAsync('P4$$w0rd')
 
     expect(result.calcTime).toBeDefined()
     result.calcTime = 0


### PR DESCRIPTION
This is duo to the painful usage with typescript.

Resolves https://github.com/zxcvbn-ts/zxcvbn/issues/77 
There wasn't another way because the check doesn't come from a parameter.