### PR TITLE
Move levenshtein dependency script into repo

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ dist2
 demo
 coverage
 data-scripts/wikiExtractor/extracts
+fastest-levenshtein.ts

--- a/packages/libraries/main/package.json
+++ b/packages/libraries/main/package.json
@@ -19,9 +19,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "fastest-levenshtein": "1.0.12"
-  },
   "keywords": [
     "password",
     "passphrase",

--- a/packages/libraries/main/src/levenshtein.ts
+++ b/packages/libraries/main/src/levenshtein.ts
@@ -1,4 +1,4 @@
-import { distance } from 'fastest-levenshtein'
+import { distance } from './vendor/fastest-levenshtein'
 import { LooseObject } from './types'
 
 const getUsedThreshold = (

--- a/packages/libraries/main/src/vendor/fastest-levenshtein.ts
+++ b/packages/libraries/main/src/vendor/fastest-levenshtein.ts
@@ -1,0 +1,148 @@
+/**
+ * This code is from https://github.com/ka-weihe/fastest-levenshtein
+ * It was copied into this repo because it doesn't have an esm build which results in error for esm only project
+ * TODO if sometimes in the future it will get a esm build we can remove this file and use the original again
+ * https://github.com/ka-weihe/fastest-levenshtein/pull/18
+ */
+const peq = new Uint32Array(0x10000)
+const myers_32 = (a: string, b: string) => {
+  const n = a.length
+  const m = b.length
+  const lst = 1 << (n - 1)
+  let pv = -1
+  let mv = 0
+  let sc = n
+  let i = n
+  while (i--) {
+    peq[a.charCodeAt(i)] |= 1 << i
+  }
+  for (i = 0; i < m; i++) {
+    let eq = peq[b.charCodeAt(i)]
+    const xv = eq | mv
+    eq |= ((eq & pv) + pv) ^ pv
+    mv |= ~(eq | pv)
+    pv &= eq
+    if (mv & lst) {
+      sc++
+    }
+    if (pv & lst) {
+      sc--
+    }
+    mv = (mv << 1) | 1
+    pv = (pv << 1) | ~(xv | mv)
+    mv &= xv
+  }
+  i = n
+  while (i--) {
+    peq[a.charCodeAt(i)] = 0
+  }
+  return sc
+}
+
+const myers_x = (b: string, a: string) => {
+  const n = a.length
+  const m = b.length
+  const mhc = []
+  const phc = []
+  const hsize = Math.ceil(n / 32)
+  const vsize = Math.ceil(m / 32)
+  for (let i = 0; i < hsize; i++) {
+    phc[i] = -1
+    mhc[i] = 0
+  }
+  let j = 0
+  for (; j < vsize - 1; j++) {
+    let mv = 0
+    let pv = -1
+    const start = j * 32
+    const vlen = Math.min(32, m) + start
+    for (let k = start; k < vlen; k++) {
+      peq[b.charCodeAt(k)] |= 1 << k
+    }
+    for (let i = 0; i < n; i++) {
+      const eq = peq[a.charCodeAt(i)]
+      const pb = (phc[(i / 32) | 0] >>> i % 32) & 1
+      const mb = (mhc[(i / 32) | 0] >>> i % 32) & 1
+      const xv = eq | mv
+      const xh = ((((eq | mb) & pv) + pv) ^ pv) | eq | mb
+      let ph = mv | ~(xh | pv)
+      let mh = pv & xh
+      if ((ph >>> 31) ^ pb) {
+        phc[(i / 32) | 0] ^= 1 << i % 32
+      }
+      if ((mh >>> 31) ^ mb) {
+        mhc[(i / 32) | 0] ^= 1 << i % 32
+      }
+      ph = (ph << 1) | pb
+      mh = (mh << 1) | mb
+      pv = mh | ~(xv | ph)
+      mv = ph & xv
+    }
+    for (let k = start; k < vlen; k++) {
+      peq[b.charCodeAt(k)] = 0
+    }
+  }
+  let mv = 0
+  let pv = -1
+  const start = j * 32
+  const vlen = Math.min(32, m - start) + start
+  for (let k = start; k < vlen; k++) {
+    peq[b.charCodeAt(k)] |= 1 << k
+  }
+  let score = m
+  for (let i = 0; i < n; i++) {
+    const eq = peq[a.charCodeAt(i)]
+    const pb = (phc[(i / 32) | 0] >>> i % 32) & 1
+    const mb = (mhc[(i / 32) | 0] >>> i % 32) & 1
+    const xv = eq | mv
+    const xh = ((((eq | mb) & pv) + pv) ^ pv) | eq | mb
+    let ph = mv | ~(xh | pv)
+    let mh = pv & xh
+    score += (ph >>> ((m % 32) - 1)) & 1
+    score -= (mh >>> ((m % 32) - 1)) & 1
+    if ((ph >>> 31) ^ pb) {
+      phc[(i / 32) | 0] ^= 1 << i % 32
+    }
+    if ((mh >>> 31) ^ mb) {
+      mhc[(i / 32) | 0] ^= 1 << i % 32
+    }
+    ph = (ph << 1) | pb
+    mh = (mh << 1) | mb
+    pv = mh | ~(xv | ph)
+    mv = ph & xv
+  }
+  for (let k = start; k < vlen; k++) {
+    peq[b.charCodeAt(k)] = 0
+  }
+  return score
+}
+
+const distance = (a: string, b: string): number => {
+  if (a.length < b.length) {
+    const tmp = b
+    b = a
+    a = tmp
+  }
+  if (b.length === 0) {
+    return a.length
+  }
+  if (a.length <= 32) {
+    return myers_32(a, b)
+  }
+  return myers_x(a, b)
+}
+
+const closest = (str: string, arr: readonly string[]): string => {
+  let min_distance = Infinity
+  let min_index = 0
+  for (let i = 0; i < arr.length; i++) {
+    const dist = distance(str, arr[i])
+    if (dist < min_distance) {
+      min_distance = dist
+      min_index = i
+    }
+  }
+  return arr[min_index]
+}
+
+export { closest, distance }

--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -3,7 +3,8 @@ import babel from '@rollup/plugin-babel'
 import commonjs from '@rollup/plugin-commonjs'
 import typescript from '@rollup/plugin-typescript'
 import del from 'rollup-plugin-delete'
-import nodeResolve from '@rollup/plugin-node-resolve'
+// TODO commented because of ./vendor/fastest-levenshtein.ts
+// import nodeResolve from '@rollup/plugin-node-resolve'
 import json from './jsonPlugin'
 
 const packagePath = process.cwd()
@@ -56,11 +57,12 @@ const generateConfig = (type) => {
 
     generateCounter += 1
   }
-  if (type === 'iife') {
-    pluginsOnlyOnce.push(nodeResolve({ resolveOnly: ['fastest-levenshtein'] }))
-  } else {
-    external.push('fastest-levenshtein')
-  }
+  // TODO commented because of ./vendor/fastest-levenshtein.ts
+  // if (type === 'iife') {
+  //   pluginsOnlyOnce.push(nodeResolve({ resolveOnly: ['fastest-levenshtein'] }))
+  // } else {
+  //   external.push('fastest-levenshtein')
+  // }
 
   return {
     input: ['./src/index.ts'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5146,11 +5146,6 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fastest-levenshtein@1.0.12:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"
-  integrity sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==
-
 fastq@^1.6.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.13.0.tgz#616760f88a7526bdfc596b7cab8c18938c36b98c"


### PR DESCRIPTION
Resolve: https://github.com/zxcvbn-ts/zxcvbn/issues/121

Moved fastest-levenshtein dependency into this repo because it doesn't have an esm build which results in error for esm only project.
This is a temporary fix because we don't know when https://github.com/ka-weihe/fastest-levenshtein/pull/18 is merged