### PR TITLE
Limit the used password string length to prevent redos attacks

### DIFF
--- a/packages/libraries/main/src/Options.ts
+++ b/packages/libraries/main/src/Options.ts
@@ -29,13 +29,13 @@ export class Options {
 
   graphs: OptionsGraph = {}
 
-  availableGraphs: string[] = []
-
   useLevenshteinDistance: boolean = false
 
   levenshteinThreshold: number = 2
 
   l33tMaxSubstitutions: number = 100
+
+  maxLength: number = 256
 
   constructor() {
     this.setRankedDictionaries()
@@ -71,6 +71,10 @@ export class Options {
 
     if (options.l33tMaxSubstitutions !== undefined) {
       this.l33tMaxSubstitutions = options.l33tMaxSubstitutions
+    }
+
+    if (options.maxLength !== undefined) {
+      this.maxLength = options.maxLength
     }
   }
 

--- a/packages/libraries/main/src/index.ts
+++ b/packages/libraries/main/src/index.ts
@@ -56,10 +56,11 @@ export const zxcvbnAsync = async (
   password: string,
   userInputs?: (string | number)[],
 ): Promise<ZxcvbnResult> => {
+  const usedPassword = password.substring(0, zxcvbnOptions.maxLength)
   const start = time()
-  const matches = await main(password, userInputs)
+  const matches = await main(usedPassword, userInputs)
 
-  return createReturnValue(matches, password, start)
+  return createReturnValue(matches, usedPassword, start)
 }
 
 export {

--- a/packages/libraries/main/src/types.ts
+++ b/packages/libraries/main/src/types.ts
@@ -161,6 +161,7 @@ export interface OptionsType {
   useLevenshteinDistance?: boolean
   levenshteinThreshold?: number
   l33tMaxSubstitutions?: number
+  maxLength?: number
 }
 
 export interface RankedDictionary {

--- a/packages/libraries/main/src/types.ts
+++ b/packages/libraries/main/src/types.ts
@@ -161,6 +161,10 @@ export interface OptionsType {
   useLevenshteinDistance?: boolean
   levenshteinThreshold?: number
   l33tMaxSubstitutions?: number
+  /**
+   * @description Defines how many character of the password are checked. A password longer than the default are considered strong anyway, but it can be increased as pleased. Be aware that this could open some attack vectors.
+   * @default 256
+   */
   maxLength?: number
 }
 

--- a/packages/libraries/main/test/main.spec.ts
+++ b/packages/libraries/main/test/main.spec.ts
@@ -158,9 +158,18 @@ describe('main', () => {
     })
   })
 
-  it('should not die while processing and have a appropriate calcTime', () => {
-    const result = zxcvbn('4@8({[</369&#!1/|0$5+7%2/4@8({[</369&#!1/|0$5+7%2/"')
-    expect(result.calcTime).toBeLessThan(2000)
+  describe('attack vectors', () => {
+    it('should not die while processing and have a appropriate calcTime for l33t attack', () => {
+      const result = zxcvbn(
+        '4@8({[</369&#!1/|0$5+7%2/4@8({[</369&#!1/|0$5+7%2/"',
+      )
+      expect(result.calcTime).toBeLessThan(2000)
+    })
+
+    it('should not die while processing and have a appropriate calcTime for regex attacks', () => {
+      const result = zxcvbn(`\x00\x00${'\x00'.repeat(100)}\n`)
+      expect(result.calcTime).toBeLessThan(2000)
+    })
   })
 
   describe('password tests', () => {


### PR DESCRIPTION
Should prevent https://github.com/dropbox/zxcvbn/issues/327 and probably other process killing attack vectors by cutting the password at a max length