### PR TITLE
Levenshtein distance performance optimization + unit tests

### DIFF
--- a/packages/libraries/main/src/levenshtein.ts
+++ b/packages/libraries/main/src/levenshtein.ts
@@ -28,6 +28,9 @@ const findLevenshteinDistance = (
   let foundDistance = 0
   const found = Object.keys(rankedDictionary).find((entry) => {
     const usedThreshold = getUsedThreshold(password, entry, threshold)
+    if (Math.abs(password.length - entry.length) > usedThreshold) {
+      return false
+    }
     const foundEntryDistance = distance(password, entry)
     const isInThreshold = foundEntryDistance <= usedThreshold
 

--- a/packages/libraries/main/test/levenshtein.spec.ts
+++ b/packages/libraries/main/test/levenshtein.spec.ts
@@ -61,4 +61,79 @@ describe('levenshtein', () => {
       ],
     })
   })
+
+  it('should recognize a mistyped common English word', () => {
+    const result = zxcvbn('alaphant')
+    expect(result.calcTime).toBeDefined()
+    result.calcTime = 0
+    expect(
+      result.sequence.find(
+        (sequenceItem) => sequenceItem.levenshteinDistance !== undefined,
+      ),
+    ).toBeDefined()
+    expect(result).toEqual({
+      calcTime: 0,
+      crackTimesDisplay: {
+        offlineFastHashing1e10PerSecond: 'less than a second',
+        offlineSlowHashing1e4PerSecond: 'less than a second',
+        onlineNoThrottling10PerSecond: '35 seconds',
+        onlineThrottling100PerHour: '3 hours',
+      },
+      crackTimesSeconds: {
+        offlineFastHashing1e10PerSecond: 3.45e-8,
+        offlineSlowHashing1e4PerSecond: 0.0345,
+        onlineNoThrottling10PerSecond: 34.5,
+        onlineThrottling100PerHour: 12420,
+      },
+      feedback: {
+        suggestions: ['Add more words that are less common.'],
+        warning: 'This is a commonly used password.',
+      },
+      guesses: 345,
+      guessesLog10: 2.537819095073274,
+      password: 'alaphant',
+      score: 0,
+      sequence: [
+        {
+          baseGuesses: 344,
+          dictionaryName: 'passwords',
+          guesses: 344,
+          guessesLog10: 2.53655844257153,
+          i: 0,
+          j: 7,
+          l33t: false,
+          l33tVariations: 1,
+          levenshteinDistance: 2,
+          levenshteinDistanceEntry: 'elephant',
+          matchedWord: 'alaphant',
+          pattern: 'dictionary',
+          rank: 344,
+          reversed: false,
+          token: 'alaphant',
+          uppercaseVariations: 1,
+        },
+      ],
+    })
+  })
+
+  it('should respect threshold which is lower than the default 2', () => {
+    zxcvbnOptions.setOptions({
+      levenshteinThreshold: 1,
+    })
+    const result = zxcvbn('eeleephaant')
+    expect(
+      result.sequence.find(
+        (sequenceItem) => sequenceItem.levenshteinDistance !== undefined,
+      ),
+    ).toBeUndefined()
+  })
+
+  it('should respect threshold which is higher than the default 2', () => {
+    zxcvbnOptions.setOptions({
+      levenshteinThreshold: 3,
+    })
+    const result = zxcvbn('eeleephaant')
+    expect(result.sequence.length).toStrictEqual(1)
+    expect(result.sequence[0].levenshteinDistance).toBeDefined()
+  })
 })


### PR DESCRIPTION
Hi! I was investigating how the library's performance could be improved when using Levenshtein distance calculation, and I managed to came up with something:

The result of the Levenshtein distance calculation is compared to a threshold value (`usedThreshold`). When comparing two strings, for example, `piracy` and `conspiracy` (their distance is `4`), with the threshold of 2, we can look at only the lengths of the two strings and the threshold, and can certainly decide without calculating the actual Levenshtein distance, that the result will be over the threshold, like this: `"conspiracy".length - "piracy".length > 2`. I added this as an early return condition in the `findLevenshteinDistance` method.

I first tested this optimization on the latest released version (`2.2.1`), and it brought notable performance improvements, namely 1.5-2x. It was around 1.5x for shorter (<~8) passwords, and 2x for longer passwords (8-10<). It could even be 2.5x for very long passwords (~32<).
But then I tried the latest revision of the `master` branch (a209561), and I saw that you implemented an other Levenshtein-related performance improvement, which makes it much faster without my optimization. Applying my patch on top of that still improves the performance by 1.2-1.5x, so there it is in a PR :slightly_smiling_face:

I also added some more Levenshtein distance unit tests as a bonus :smiley: