### PR TITLE
Separator matching cleanup

### DIFF
--- a/packages/libraries/main/src/data/const.ts
+++ b/packages/libraries/main/src/data/const.ts
@@ -22,5 +22,17 @@ export const ALPHA_INVERTED = /[^A-Za-z\xbf-\xdf]/gi
 export const ALL_DIGIT = /^\d+$/
 export const REFERENCE_YEAR = new Date().getFullYear()
 export const REGEXEN = { recentYear: /19\d\d|200\d|201\d|202\d/g }
-// Rough scale of special characters people may use for separators
-export const SPECIAL_CHAR_COUNT = 16
+/* Separators */
+export const SEPERATOR_CHARS = [
+  ' ',
+  ',',
+  ';',
+  ':',
+  '|',
+  '/',
+  '\\',
+  '_',
+  '.',
+  '-',
+]
+export const SEPERATOR_CHAR_COUNT = SEPERATOR_CHARS.length

--- a/packages/libraries/main/src/matcher/repeat/matching.ts
+++ b/packages/libraries/main/src/matcher/repeat/matching.ts
@@ -1,7 +1,6 @@
 import { RepeatMatch } from '../../types'
 import scoring from '../../scoring'
 import Matching from '../../Matching'
-import { SEPERATOR_CHARS } from '../../data/const'
 
 function createRegex({
   isLazy = false,
@@ -9,9 +8,9 @@ function createRegex({
   flags = '',
 }): RegExp {
   return new RegExp(
-    `${isAnchored ? '^' : ''}([^${SEPERATOR_CHARS.join('')}]+${
-      isLazy ? '?' : ''
-    })\\1+${isAnchored ? '$' : ''}`,
+    `${isAnchored ? '^' : ''}(.+${isLazy ? '?' : ''})\\1+${
+      isAnchored ? '$' : ''
+    }`,
     flags,
   )
 }

--- a/packages/libraries/main/src/matcher/repeat/matching.ts
+++ b/packages/libraries/main/src/matcher/repeat/matching.ts
@@ -1,6 +1,7 @@
 import { RepeatMatch } from '../../types'
 import scoring from '../../scoring'
 import Matching from '../../Matching'
+import { SEPERATOR_CHARS } from '../../data/const'
 
 function createRegex({
   isLazy = false,
@@ -8,9 +9,9 @@ function createRegex({
   flags = '',
 }): RegExp {
   return new RegExp(
-    `${isAnchored ? '^' : ''}(.+${isLazy ? '?' : ''})\\1+${
-      isAnchored ? '$' : ''
-    }`,
+    `${isAnchored ? '^' : ''}([^${SEPERATOR_CHARS.join('')}]+${
+      isLazy ? '?' : ''
+    })\\1+${isAnchored ? '$' : ''}`,
     flags,
   )
 }

--- a/packages/libraries/main/src/matcher/separator/matching.ts
+++ b/packages/libraries/main/src/matcher/separator/matching.ts
@@ -1,8 +1,11 @@
+import { SEPERATOR_CHARS } from '../../data/const'
 import { SeparatorMatch } from '../../types'
 
 interface SeparatorMatchOptions {
   password: string
 }
+
+const separatorRegex = new RegExp(`[${SEPERATOR_CHARS.join('')}]`)
 
 /*
  *-------------------------------------------------------------------------------
@@ -10,11 +13,11 @@ interface SeparatorMatchOptions {
  *-------------------------------------------------------------------------------
  */
 class MatchSeparator {
-  static getMostUsedSpecialChar(password: string): string | undefined {
-    const mostUsedSpecials = [
+  static getMostUsedSeparatorChar(password: string): string | undefined {
+    const mostUsedSeperators = [
       ...password
         .split('')
-        .filter((c) => /[^\w]/.test(c))
+        .filter((c) => separatorRegex.test(c))
         .reduce((memo, c) => {
           const m = memo.get(c)
           if (m) {
@@ -26,8 +29,8 @@ class MatchSeparator {
         }, new Map())
         .entries(),
     ].sort(([_a, a], [_b, b]) => b - a)
-    if (!mostUsedSpecials.length) return undefined
-    const match = mostUsedSpecials[0]
+    if (!mostUsedSeperators.length) return undefined
+    const match = mostUsedSeperators[0]
     // If the special character is only used once, don't treat it like a separator
     if (match[1] < 2) return undefined
     return match[0]
@@ -43,7 +46,7 @@ class MatchSeparator {
 
     if (password.length === 0) return result
 
-    const mostUsedSpecial = MatchSeparator.getMostUsedSpecialChar(password)
+    const mostUsedSpecial = MatchSeparator.getMostUsedSeparatorChar(password)
     if (mostUsedSpecial === undefined) return result
 
     const isSeparator = MatchSeparator.getSeparatorRegex(mostUsedSpecial)

--- a/packages/libraries/main/src/matcher/separator/scoring.ts
+++ b/packages/libraries/main/src/matcher/separator/scoring.ts
@@ -1,5 +1,5 @@
-import { SPECIAL_CHAR_COUNT } from '../../data/const'
+import { SEPERATOR_CHAR_COUNT } from '../../data/const'
 
 export default () => {
-  return SPECIAL_CHAR_COUNT
+  return SEPERATOR_CHAR_COUNT
 }

--- a/packages/libraries/main/src/scoring/index.ts
+++ b/packages/libraries/main/src/scoring/index.ts
@@ -10,7 +10,7 @@ import {
 import MatchSeparator from '../matcher/separator/matching'
 
 const scoringHelper = {
-  password: '',
+  _password: '',
   optimal: {} as any,
   excludeAdditive: false,
   separatorRegex: undefined as RegExp | null | undefined,
@@ -26,6 +26,15 @@ const scoringHelper = {
     }
     return result
   },
+  set password(pass: string) {
+    // eslint-disable-next-line no-underscore-dangle
+    this._password = pass
+    this.separatorRegex = undefined
+  },
+  get password() {
+    // eslint-disable-next-line no-underscore-dangle
+    return this._password
+  },
   // helper: make bruteforce match objects spanning i to j, inclusive.
   makeBruteforceMatch(i: number, j: number): BruteForceMatch {
     return {
@@ -40,7 +49,7 @@ const scoringHelper = {
     endIndex: number,
   ): number | undefined {
     if (this.separatorRegex === undefined) {
-      const mostUsedSpecial = MatchSeparator.getMostUsedSpecialChar(
+      const mostUsedSpecial = MatchSeparator.getMostUsedSeparatorChar(
         this.password,
       )
       if (mostUsedSpecial === undefined) {

--- a/packages/libraries/main/src/scoring/index.ts
+++ b/packages/libraries/main/src/scoring/index.ts
@@ -7,10 +7,9 @@ import {
   MatchEstimated,
   LooseObject,
 } from '../types'
-import MatchSeparator from '../matcher/separator/matching'
 
 const scoringHelper = {
-  _password: '',
+  password: '',
   optimal: {} as any,
   excludeAdditive: false,
   separatorRegex: undefined as RegExp | null | undefined,
@@ -26,15 +25,6 @@ const scoringHelper = {
     }
     return result
   },
-  set password(pass: string) {
-    // eslint-disable-next-line no-underscore-dangle
-    this._password = pass
-    this.separatorRegex = undefined
-  },
-  get password() {
-    // eslint-disable-next-line no-underscore-dangle
-    return this._password
-  },
   // helper: make bruteforce match objects spanning i to j, inclusive.
   makeBruteforceMatch(i: number, j: number): BruteForceMatch {
     return {
@@ -43,31 +33,6 @@ const scoringHelper = {
       i,
       j,
     }
-  },
-  getLastSeparatorIdx(
-    startIndex: number,
-    endIndex: number,
-  ): number | undefined {
-    if (this.separatorRegex === undefined) {
-      const mostUsedSpecial = MatchSeparator.getMostUsedSeparatorChar(
-        this.password,
-      )
-      if (mostUsedSpecial === undefined) {
-        this.separatorRegex = null
-      } else {
-        this.separatorRegex = MatchSeparator.getSeparatorRegex(mostUsedSpecial)
-      }
-    }
-    if (this.separatorRegex === null) return undefined
-
-    const separators = [
-      ...this.password
-        .slice(startIndex, endIndex + 1)
-        .matchAll(this.separatorRegex),
-    ]
-    if (!separators.length) return undefined
-
-    return separators[separators.length - 1].index ?? 0
   },
   // helper: considers whether a length-sequenceLength
   // sequence ending at match m is better (fewer guesses)
@@ -113,15 +78,9 @@ const scoringHelper = {
   bruteforceUpdate(passwordCharIndex: number) {
     // see if a single bruteforce match spanning the passwordCharIndex-prefix is optimal.
     let match = this.makeBruteforceMatch(0, passwordCharIndex)
-    const lastSeparatorIdx = this.getLastSeparatorIdx(0, passwordCharIndex)
-    let i = 1
-    if (lastSeparatorIdx !== undefined) {
-      i = lastSeparatorIdx + 1
-    } else {
-      this.update(match, 1)
-    }
+    this.update(match, 1)
 
-    for (; i <= passwordCharIndex; i += 1) {
+    for (let i = 1; i <= passwordCharIndex; i += 1) {
       // generate passwordCharIndex bruteforce matches, spanning from (i=1, j=passwordCharIndex) up to (i=passwordCharIndex, j=passwordCharIndex).
       // see if adding these new matches to any of the sequences in optimal[i-1]
       // leads to new bests.

--- a/packages/libraries/main/test/matcher/separator/scoring.spec.ts
+++ b/packages/libraries/main/test/matcher/separator/scoring.spec.ts
@@ -1,14 +1,8 @@
-import { SPECIAL_CHAR_COUNT } from '../../../src/data/const'
+import { SEPERATOR_CHARS, SEPERATOR_CHAR_COUNT } from '../../../src/data/const'
 import separatorGuesses from '../../../src/matcher/separator/scoring'
 
 describe('scoring: guesses separator', () => {
-  const data = [
-    [' ', SPECIAL_CHAR_COUNT],
-    ['%', SPECIAL_CHAR_COUNT],
-    ['-', SPECIAL_CHAR_COUNT],
-    ['.', SPECIAL_CHAR_COUNT],
-    ['_', SPECIAL_CHAR_COUNT],
-  ]
+  const data = SEPERATOR_CHARS.map((s) => [s, SEPERATOR_CHAR_COUNT])
 
   data.forEach(([token, guesses]) => {
     const match = {

--- a/scripts/cli-password-tester.ts
+++ b/scripts/cli-password-tester.ts
@@ -1,0 +1,28 @@
+// eslint-disable-next-line import/no-relative-packages
+import * as zxcvbnCommonPackage from '@zxcvbn-ts/language-common/src/index'
+import * as zxcvbnEnPackage from '@zxcvbn-ts/language-en/src/index'
+import { zxcvbnAsync, zxcvbnOptions } from '@zxcvbn-ts/core/src/index'
+
+// eslint-disable-next-line prettier/prettier
+(async () => {
+  const options = {
+    dictionary: {
+      ...zxcvbnCommonPackage.dictionary,
+      ...zxcvbnEnPackage.dictionary,
+    },
+    translations: zxcvbnEnPackage.translations,
+    graphs: zxcvbnCommonPackage.adjacencyGraphs,
+    useLevenshteinDistance: true,
+  }
+  zxcvbnOptions.setOptions(options)
+  return zxcvbnAsync(process.argv[2], process.argv[3]?.split(';'))
+})()
+  .then((match) => {
+    // eslint-disable-next-line no-console
+    console.log(match)
+    process.exit(0)
+  })
+  .catch((e: Error) => {
+    console.error(e)
+    process.exit(1)
+  })


### PR DESCRIPTION
This is to finish up the changes made from #115 and to further address #193 

Please see the discussion in that ticket for more details as to what changes were made here and why.

The bruteforce and repeater matching are not aware of separators to allow for more options for the matcher to choose from to determine the lowest score possible.

Separators are matched:
* From a specific subset of special chars (no config for now)
* Only using the most used one in the password (the rest are ignored as separators)
* Only if it occurs 2 or more times (e.g. a single separator won't match as a separator, and is treated as a normal special char)

Separators are scored:
* As a minimal amount (the number of chars in the subset of special chars treated as special chars and applied only to the one character of the password)
* Subsequent usages of a separator are treated as 0 complexity in the password as it is assumed that a guesser who knows the separator would just reuse it. Note: this may be a bad assumption and it doesn't 100% work in the scoring as if the algorithm doesn't pick the first instance of the separator as a separator, the score is never added for subsequent matches that do get used.