### PR TITLE
Fix getCleanPasswords results when replacement length exceeds 1

### DIFF
--- a/packages/libraries/main/src/matcher/dictionary/variants/matching/unmunger/getCleanPasswords.ts
+++ b/packages/libraries/main/src/matcher/dictionary/variants/matching/unmunger/getCleanPasswords.ts
@@ -65,7 +65,7 @@ const getAllSubCombosHelper = ({
           // recursively build the rest of the string
           helper(i + 1, newSubs)
           // backtrack by ignoring the added postfix
-          buffer.splice(-sub.length)
+          buffer.pop()
           if (finalPasswords.length >= limit) {
             return
           }

--- a/packages/libraries/main/test/matcher/dictionary/variant/matching/unmunger/__snapshots__/getCleanPasswords.spec.ts.snap
+++ b/packages/libraries/main/test/matcher/dictionary/variant/matching/unmunger/__snapshots__/getCleanPasswords.spec.ts.snap
@@ -229,3 +229,43 @@ exports[`getCleanPasswords should limit the substitutions correctly 1`] = `
   },
 ]
 `;
+
+exports[`getCleanPasswords should substitute to multiple symbols correctly 1`] = `
+[
+  {
+    "changes": [],
+    "password": "p@ciﬁc",
+  },
+  {
+    "changes": [
+      {
+        "letter": "fi",
+        "substitution": "ﬁ",
+      },
+    ],
+    "password": "p@cific",
+  },
+  {
+    "changes": [
+      {
+        "letter": "a",
+        "substitution": "@",
+      },
+    ],
+    "password": "paciﬁc",
+  },
+  {
+    "changes": [
+      {
+        "letter": "a",
+        "substitution": "@",
+      },
+      {
+        "letter": "fi",
+        "substitution": "ﬁ",
+      },
+    ],
+    "password": "pacific",
+  },
+]
+`;

--- a/packages/libraries/main/test/matcher/dictionary/variant/matching/unmunger/getCleanPasswords.spec.ts
+++ b/packages/libraries/main/test/matcher/dictionary/variant/matching/unmunger/getCleanPasswords.spec.ts
@@ -7,6 +7,7 @@ const trieNode = l33tTableToTrieNode(
     a: ['@', '4'],
     u: ['|_|'],
     m: ['^^', 'nn', '2n', '/\\\\/\\\\'],
+    fi: ['ﬁ'],
   },
   new TrieNode(),
 )
@@ -17,5 +18,9 @@ describe('getCleanPasswords', () => {
 
   it('should limit the substitutions correctly', () => {
     expect(getCleanPasswords('P4|_|$nn4rd', 2, trieNode)).toMatchSnapshot()
+  })
+
+  it('should substitute to multiple symbols correctly', () => {
+    expect(getCleanPasswords('p@ciﬁc', 100, trieNode)).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
sub is added to the buffer as an array element, but removed as if the buffer were a string. This leads to loss of symbols in generated variants when sub.length > 1.