### PR TITLE
Resolve bundler issues where crypto is blocking

### DIFF
--- a/packages/libraries/pwned/package.json
+++ b/packages/libraries/pwned/package.json
@@ -16,6 +16,9 @@
     "dist",
     "src"
   ],
+  "browser": {
+    "crypto": false
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Resolves https://github.com/zxcvbn-ts/zxcvbn/issues/224

This should tell bundlers like webpack to ignore the crypto module while bundling in a consumer app of this library