### PR TITLE
Improve DE translations

### DIFF
--- a/packages/languages/de/src/translations.ts
+++ b/packages/languages/de/src/translations.ts
@@ -14,12 +14,12 @@ export default {
     topHundred: 'Dies ist ein häufig verwendetes Passwort.',
     common: 'Dies ist ein oft verwendetes Passwort.',
     similarToCommon:
-      'Dies weist Ähnlichkeit zu anderen oft verwendeten Passwörtern auf.',
+      'Dieses Passwort weist Ähnlichkeit zu anderen, oft verwendeten Passwörtern auf.',
     wordByItself: 'Einzelne Wörter sind leicht zu erraten.',
     namesByThemselves: 'Einzelne Namen oder Nachnamen sind leicht zu erraten.',
     commonNames: 'Vornamen und Nachnamen sind leicht zu erraten.',
     userInputs:
-      'Es sollten keine persönlichen oder Seiten relevanten Daten vorkommen.',
+      'Das Passwort enthält personliche Daten oder nimmt Bezug auf diese Webseite.',
     pwned: 'Ihr Kennwort wurde durch eine Datenpanne im Internet offengelegt.',
   },
   suggestions: {


### PR DESCRIPTION
Some of the feedback translations sounded a bit clunky.

Translating the `userInputs` warning back into English, it would mean sth. along "The password contains personal data or could be related to this website.". The previous localization "Es sollten keine persönlichen oder Seiten relevanten Daten vorkommen." contained an uncommon phrase ("Seiten relevant", which would need a hyphenation anyway).