### PR TITLE
Remove gzip/base64 in dictionaries as it increases the bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@vuepress/bundler-vite": "2.0.0-rc.17",
     "@vuepress/plugin-register-components": "2.0.0-rc.52",
     "@vuepress/theme-default": "2.0.0-rc.52",
-    "@zxcvbn-ts/dictionary-compression": "^2.0.0",
+    "@zxcvbn-ts/dictionary-compression": "^3.0.1",
     "axios": "1.7.7",
     "byline": "5.0.0",
     "cross-fetch": "4.0.0",

--- a/packages/languages/ar/package.json
+++ b/packages/languages/ar/package.json
@@ -27,6 +27,6 @@
     "arabic"
   ],
   "dependencies": {
-    "@zxcvbn-ts/dictionary-compression": "^2.0.0"
+     "@zxcvbn-ts/dictionary-compression": "^3.0.1"
   }
 }

--- a/packages/languages/common/package.json
+++ b/packages/languages/common/package.json
@@ -27,6 +27,6 @@
     "common"
   ],
   "dependencies": {
-    "@zxcvbn-ts/dictionary-compression": "^2.0.0"
+     "@zxcvbn-ts/dictionary-compression": "^3.0.1"
   }
 }

--- a/packages/languages/cs/package.json
+++ b/packages/languages/cs/package.json
@@ -27,6 +27,6 @@
     "czech"
   ],
   "dependencies": {
-    "@zxcvbn-ts/dictionary-compression": "^2.0.0"
+     "@zxcvbn-ts/dictionary-compression": "^3.0.1"
   }
 }

--- a/packages/languages/da-dk/package.json
+++ b/packages/languages/da-dk/package.json
@@ -27,6 +27,6 @@
     "danish"
   ],
   "dependencies": {
-    "@zxcvbn-ts/dictionary-compression": "^2.0.0"
+     "@zxcvbn-ts/dictionary-compression": "^3.0.1"
   }
 }

--- a/packages/languages/de/package.json
+++ b/packages/languages/de/package.json
@@ -27,6 +27,6 @@
     "german"
   ],
   "dependencies": {
-    "@zxcvbn-ts/dictionary-compression": "^2.0.0"
+     "@zxcvbn-ts/dictionary-compression": "^3.0.1"
   }
 }

--- a/packages/languages/en/package.json
+++ b/packages/languages/en/package.json
@@ -27,6 +27,6 @@
     "english"
   ],
   "dependencies": {
-    "@zxcvbn-ts/dictionary-compression": "^2.0.0"
+     "@zxcvbn-ts/dictionary-compression": "^3.0.1"
   }
 }

--- a/packages/languages/es-es/package.json
+++ b/packages/languages/es-es/package.json
@@ -28,6 +28,6 @@
     "spain"
   ],
   "dependencies": {
-    "@zxcvbn-ts/dictionary-compression": "^2.0.0"
+     "@zxcvbn-ts/dictionary-compression": "^3.0.1"
   }
 }

--- a/packages/languages/fi/package.json
+++ b/packages/languages/fi/package.json
@@ -27,6 +27,6 @@
     "finnish"
   ],
   "dependencies": {
-    "@zxcvbn-ts/dictionary-compression": "^2.0.0"
+     "@zxcvbn-ts/dictionary-compression": "^3.0.1"
   }
 }

--- a/packages/languages/fr/package.json
+++ b/packages/languages/fr/package.json
@@ -27,6 +27,6 @@
     "french"
   ],
   "dependencies": {
-    "@zxcvbn-ts/dictionary-compression": "^2.0.0"
+     "@zxcvbn-ts/dictionary-compression": "^3.0.1"
   }
 }

--- a/packages/languages/id/package.json
+++ b/packages/languages/id/package.json
@@ -27,6 +27,6 @@
     "indonesia"
   ],
   "dependencies": {
-    "@zxcvbn-ts/dictionary-compression": "^2.0.0"
+     "@zxcvbn-ts/dictionary-compression": "^3.0.1"
   }
 }

--- a/packages/languages/it/package.json
+++ b/packages/languages/it/package.json
@@ -27,6 +27,6 @@
     "italian"
   ],
   "dependencies": {
-    "@zxcvbn-ts/dictionary-compression": "^2.0.0"
+     "@zxcvbn-ts/dictionary-compression": "^3.0.1"
   }
 }

--- a/packages/languages/ja/package.json
+++ b/packages/languages/ja/package.json
@@ -27,6 +27,6 @@
     "japanese"
   ],
   "dependencies": {
-    "@zxcvbn-ts/dictionary-compression": "^2.0.0"
+     "@zxcvbn-ts/dictionary-compression": "^3.0.1"
   }
 }

--- a/packages/languages/nl-be/package.json
+++ b/packages/languages/nl-be/package.json
@@ -28,6 +28,6 @@
     "belgium"
   ],
   "dependencies": {
-    "@zxcvbn-ts/dictionary-compression": "^2.0.0"
+     "@zxcvbn-ts/dictionary-compression": "^3.0.1"
   }
 }

--- a/packages/languages/pl/package.json
+++ b/packages/languages/pl/package.json
@@ -29,6 +29,6 @@
     "pl"
   ],
   "dependencies": {
-    "@zxcvbn-ts/dictionary-compression": "^2.0.0"
+     "@zxcvbn-ts/dictionary-compression": "^3.0.1"
   }
 }

--- a/packages/languages/pt-br/package.json
+++ b/packages/languages/pt-br/package.json
@@ -31,6 +31,6 @@
     "ptbr"
   ],
   "dependencies": {
-    "@zxcvbn-ts/dictionary-compression": "^2.0.0"
+     "@zxcvbn-ts/dictionary-compression": "^3.0.1"
   }
 }

--- a/scripts/jsonPlugin.mjs
+++ b/scripts/jsonPlugin.mjs
@@ -20,7 +20,7 @@ const json = () => {
           code = `
 import decompress from '@zxcvbn-ts/dictionary-compression/decompress'
 
-export default decompress('${encoded}')`
+export default decompress("${encoded}")`
         } else {
           const data = JSON.stringify(parsed)
           code = `export default ${data}`

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,11 +2,6 @@
 # yarn lockfile v1
 
 
-"@alttiri/base85@1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@alttiri/base85/-/base85-1.8.0.tgz#9a859a9b9bd1847173260e37b58d6fc6c8fd50ce"
-  integrity sha512-HrfdFtOPJ2dlZjHcCDgd9o4ph9+iQnZ+ayWNALImDm1VLv46aMriO13QZ0bpZuvDc8XbPcQK2rb4o38Xt+MMpA==
-
 "@ampproject/remapping@^2.2.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.3.0.tgz#ed441b6fa600072520ce18b43d2c8cc8caecc7f4"
@@ -3339,13 +3334,10 @@
   dependencies:
     argparse "^2.0.1"
 
-"@zxcvbn-ts/dictionary-compression@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@zxcvbn-ts/dictionary-compression/-/dictionary-compression-2.0.0.tgz#6a180a9ecf0fba98d87d58c5955fdab9245b65f5"
-  integrity sha512-gTUSR73B2IDfg7PccGRbwOm5wurK0D1LobQsUyLPqe7pOZ4iQYMJfJ3F0dyMjFlRsc2hmdM2gyPX8HWq4nl9VQ==
-  dependencies:
-    "@alttiri/base85" "1.8.0"
-    fflate "^0.8.2"
+"@zxcvbn-ts/dictionary-compression@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@zxcvbn-ts/dictionary-compression/-/dictionary-compression-3.0.1.tgz#f357ad46e08fff8ba92f6f163d6b38b9533fc849"
+  integrity sha512-p3KyPzxGc3vWSap5hHA6SllbUCmh7s+NtpGyC3qEWrxYJT9t9TUAzjPm48Okipo+UUyPQfDlIvTcs9JRShBFiQ==
 
 JSONStream@^1.3.5:
   version "1.3.5"


### PR DESCRIPTION
@mimi89999 unfortunately i needed to remove the pre gzip/base64 encoding from the compress library as the browser build were getting bigger instead of smaller. 

Here are my test result with a basic nginx gzip configuration and vite chunks:

3.x.x
    common: 232kb
    en: 565kb

4.x.x
    common: 247kb => +15kb
    en: 591kb => +26kb

4.x.x without pre gzip/base64
    common: 225kb => -7kb
    en: 493kb => -72kb

But i will keep some suggestion by lifthrasiir from https://github.com/zxcvbn-ts/zxcvbn/issues/254
