### PR TITLE
fix(matcher-pwned): use Web Crypto in HIBP digest, drop Node-specific require('crypto') branch

### DIFF
--- a/packages/libraries/pwned/src/haveIBeenPwned.ts
+++ b/packages/libraries/pwned/src/haveIBeenPwned.ts
@@ -1,17 +1,6 @@
 import { HaveIBeenPwnedConfig } from './types'
 
-const isNodeJs =
-  typeof process !== 'undefined' && process.release?.name === 'node'
-
 const textEncode = (text: string) => {
-  if (isNodeJs) {
-    const utf8 = decodeURI(encodeURIComponent(text))
-    const result = new Uint8Array(utf8.length)
-    for (let i = 0; i < utf8.length; i += 1) {
-      result[i] = utf8.charCodeAt(i)
-    }
-    return result
-  }
   try {
     return new TextEncoder().encode(text)
   } catch (error: any) {
@@ -21,20 +10,12 @@ const textEncode = (text: string) => {
 
 const digestMessage = async (message: string) => {
   const data = textEncode(message)
-  let hash = ''
-  if (isNodeJs) {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const crypto = require('crypto')
-    hash = crypto.createHash('sha1').update(message).digest('hex').toUpperCase()
-  } else if (crypto) {
-    const hashBuffer = await crypto.subtle.digest('SHA-1', data)
-    const hashArray = Array.from(new Uint8Array(hashBuffer))
-    hash = hashArray
-      .map((b) => b.toString(16).padStart(2, '0'))
-      .join('')
-      .toUpperCase()
-  }
-  return hash
+  const hashBuffer = await crypto.subtle.digest('SHA-1', data)
+  const hashArray = Array.from(new Uint8Array(hashBuffer))
+  return hashArray
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+    .toUpperCase()
 }
 
 const pwnedUrl = 'https://api.pwnedpasswords.com/range/'


### PR DESCRIPTION
## Problem

Bundlers that target Node ESM (esbuild, Vite, Rollup with `output.format: "esm"`, `tsup --format esm`, etc.) emit a runtime crash for any consumer of `@zxcvbn-ts/matcher-pwned` the first time the HIBP matcher is invoked:

```
Error: Dynamic require of "crypto" is not supported
```

The cause is in `packages/libraries/pwned/src/haveIBeenPwned.ts`:

```ts
const digestMessage = async (message: string) => {
  // …
  if (isNodeJs) {
    // eslint-disable-next-line @typescript-eslint/no-require-imports
    const crypto = require('crypto')
    hash = crypto.createHash('sha1').update(message).digest('hex').toUpperCase()
  } else if (crypto) {
    // Web Crypto path
  }
}
```

After Rollup emits the package's ESM build (`dist/haveIBeenPwned.mjs`), that `require('crypto')` survives as an unresolved synchronous CJS require inside an ESM module. esbuild and similar bundlers wrap unknown `require()` calls in a stub that throws at runtime the first time the branch is taken — i.e. as soon as a consuming Node app calls the matcher.

This is the well-known "dual ESM/CJS hazard": the file is shipped as ESM but its body still uses CommonJS module loading. Browser consumers were unaffected because `isNodeJs` is `false` there; pure Node CJS consumers were unaffected because `require` resolves natively. ESM Node consumers (which is now the default for any new project bundling with esbuild/Vite/Rollup) hit it on the first call.

## Repro

Any Node ESM project that bundles `@zxcvbn-ts/matcher-pwned` and calls the matcher will crash. Minimal repro using esbuild:

```js
// build.js
import { build } from 'esbuild'
build({
  entryPoints: ['app.ts'],
  bundle: true,
  platform: 'node',
  format: 'esm',
  outfile: 'dist/app.js',
  // typical Node-ESM externals for CJS deps would not include matcher-pwned
}).catch(() => process.exit(1))
```

```ts
// app.ts
import { matcherPwnedFactory } from '@zxcvbn-ts/matcher-pwned'
const matcher = matcherPwnedFactory(fetch)
await matcher.match({ password: 'P4$$w0rd' }) // throws "Dynamic require of crypto is not supported"
```

## Root cause

The file extension says ESM (`dist/haveIBeenPwned.mjs`) but the body uses synchronous CommonJS `require()`. The Node branch was originally added to give Node ≤18 a non-Web-Crypto fallback (Node 19 is the first version that exposes `globalThis.crypto.subtle`). It is now dead code under this project's own support contract.

## Fix

Drop the Node-specific branch from both `digestMessage` and `textEncode`. Use the universally-available `crypto.subtle.digest('SHA-1', …)` and `TextEncoder` unconditionally. The `isNodeJs` flag has no other consumers and is removed.

```diff
-  const isNodeJs =
-    typeof process !== 'undefined' && process.release?.name === 'node'

   const textEncode = (text: string) => {
-    if (isNodeJs) {
-      const utf8 = decodeURI(encodeURIComponent(text))
-      const result = new Uint8Array(utf8.length)
-      for (let i = 0; i < utf8.length; i += 1) {
-        result[i] = utf8.charCodeAt(i)
-      }
-      return result
-    }
     try {
       return new TextEncoder().encode(text)
     } catch (error: any) {
       throw new Error(`No encoder found, ${error}`)
     }
   }

   const digestMessage = async (message: string) => {
     const data = textEncode(message)
-    let hash = ''
-    if (isNodeJs) {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const crypto = require('crypto')
-      hash = crypto.createHash('sha1').update(message).digest('hex').toUpperCase()
-    } else if (crypto) {
-      const hashBuffer = await crypto.subtle.digest('SHA-1', data)
-      const hashArray = Array.from(new Uint8Array(hashBuffer))
-      hash = hashArray
-        .map((b) => b.toString(16).padStart(2, '0'))
-        .join('')
-        .toUpperCase()
-    }
-    return hash
+    const hashBuffer = await crypto.subtle.digest('SHA-1', data)
+    const hashArray = Array.from(new Uint8Array(hashBuffer))
+    return hashArray
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('')
+      .toUpperCase()
   }
```

Net result: -25/+6 lines, single code path for every supported runtime, no `require()` in the ESM bundle.

## Why dropping the Node branch is safe

- No `engines` field in `package.json` — there is no documented commitment to Node ≤18.
- `.github/workflows/test.js.yml` runs CI on `node-version: [24.x]` only — older Node versions are not exercised by the project's own test matrix.
- Node 18 reached EOL on 2025-04-30 — every supported Node release exposes `globalThis.crypto.subtle` and `TextEncoder`.
- Same APIs are available in browsers, Deno, Bun, Cloudflare Workers, and other Edge runtimes — the file already targeted them via the `else if (crypto)` branch.

## Alternative considered

Keep a `process.versions.node` major-version check that falls back to `node:crypto` for Node ≤18 users. Rejected because:

1. The project's CI doesn't exercise those versions, so the fallback would be untested.
2. It would need an `import` (not `require`) of `node:crypto` to stay ESM-clean, which forces every consumer to declare `node:crypto` as external — a worse footgun than the original bug.
3. Node 18 is EOL and there is no documented commitment to support it.

## Behavior parity

`crypto.subtle.digest('SHA-1', data)` produces the same SHA-1 digest as `node:crypto.createHash('sha1').update(message).digest('hex')`. The matcher-pwned test suite already exercises the digest path end-to-end:

- `packages/libraries/pwned/test/index.spec.ts` calls `zxcvbn.checkAsync('P4$$w0rd')` against a mocked HIBP response containing the SHA-1-suffix `08A205652858375D71117A63004CC75167` — the test asserts the matcher finds the entry, which is only possible if the digest is computed correctly.

That test passes both before and after this change.

## Verification

Local toolchain run on Node 24.14.0:

- `yarn build`: succeeds. New `packages/libraries/pwned/dist/haveIBeenPwned.mjs` contains zero `require(` occurrences (`grep -E "require\\s*\\(" dist/haveIBeenPwned.mjs` → 0 hits).
- `yarn test`: 41 suites, **1178 passed, 1 skipped, 0 failed**.
- `yarn typecheck`: clean.
- `yarn lint`: clean.

## Compatibility

- ESM consumers: previously broken (runtime crash) — now work.
- CJS consumers: unchanged — `dist/haveIBeenPwned.cjs` builds the same single Web Crypto code path, which works on Node 19+ exactly as it does on Node 24.
- Browser consumers: unchanged.
- The `"browser": { "crypto": false }` field in `package.json` was used by webpack-style bundlers to stub out the Node `crypto` builtin for the browser branch; it is now harmless dead config (kept untouched to keep this PR focused on the bug fix).

No breaking changes.