### PR TITLE
Fix message for `l33t` suggestion in translation

### DIFF
--- a/packages/languages/es-es/src/translations.ts
+++ b/packages/languages/es-es/src/translations.ts
@@ -20,7 +20,7 @@ export default {
     pwned: 'Su contraseña fue expuesta por una violación de datos en Internet.',
   },
   suggestions: {
-    l33t: "Evita sustituciones predecibles como '@' por 'a'."
+    l33t: "Evita sustituciones predecibles como '@' por 'a'.",
     reverseWords: 'Evita palabras comunes escritas al revés',
     allUppercase: 'Escribe en mayúsculas algunas, pero no todas las letras.',
     capitalization:

--- a/packages/languages/es-es/src/translations.ts
+++ b/packages/languages/es-es/src/translations.ts
@@ -20,7 +20,7 @@ export default {
     pwned: 'Su contraseña fue expuesta por una violación de datos en Internet.',
   },
   suggestions: {
-    l33t: "Evita sustituciones predecibles como '@' por 'a'.",
+    l33t: 'Evita sustituciones predecibles como "@" por "a".',
     reverseWords: 'Evita palabras comunes escritas al revés',
     allUppercase: 'Escribe en mayúsculas algunas, pero no todas las letras.',
     capitalization:

--- a/packages/languages/es-es/src/translations.ts
+++ b/packages/languages/es-es/src/translations.ts
@@ -20,7 +20,7 @@ export default {
     pwned: 'Su contraseña fue expuesta por una violación de datos en Internet.',
   },
   suggestions: {
-    l33t: "Evita sustituciones predecibles como 'a' por '@'",
+    l33t: "Evita sustituciones predecibles como '@' por 'a'",
     reverseWords: 'Evita palabras comunes escritas al revés',
     allUppercase: 'Escribe en mayúsculas algunas, pero no todas las letras.',
     capitalization:

--- a/packages/languages/es-es/src/translations.ts
+++ b/packages/languages/es-es/src/translations.ts
@@ -20,7 +20,7 @@ export default {
     pwned: 'Su contraseña fue expuesta por una violación de datos en Internet.',
   },
   suggestions: {
-    l33t: "Evita sustituciones predecibles como '@' por 'a'",
+    l33t: "Evita sustituciones predecibles como '@' por 'a'."
     reverseWords: 'Evita palabras comunes escritas al revés',
     allUppercase: 'Escribe en mayúsculas algunas, pero no todas las letras.',
     capitalization:

--- a/packages/languages/es-es/src/translations.ts
+++ b/packages/languages/es-es/src/translations.ts
@@ -20,7 +20,7 @@ export default {
     pwned: 'Su contraseña fue expuesta por una violación de datos en Internet.',
   },
   suggestions: {
-    l33t: "Evita sustituciones predecibles como '@' por '@'",
+    l33t: "Evita sustituciones predecibles como 'a' por '@'",
     reverseWords: 'Evita palabras comunes escritas al revés',
     allUppercase: 'Escribe en mayúsculas algunas, pero no todas las letras.',
     capitalization:

--- a/packages/languages/ro/src/translations.ts
+++ b/packages/languages/ro/src/translations.ts
@@ -21,7 +21,7 @@ export default {
       'Parola ta a fost expusă de o încălcare a securității datelor pe internet.',
   },
   suggestions: {
-    l33t: 'Evită substituțiile previzibile, cum ar fi "@" pentru "@".',
+    l33t: 'Evită substituțiile previzibile, cum ar fi "@" pentru "a".',
     reverseWords: 'Evită cuvintele comune scrise invers',
     allUppercase: 'Scrie cu majuscule unele litere, dar nu toate literele.',
     capitalization:


### PR DESCRIPTION
Translations in Spanish and Romanian do not really reflect what it should be said.

For reference, this is the English translation:

https://github.com/zxcvbn-ts/zxcvbn/blob/2199f628c909167ef0c14cb70626e059cf578a7a/packages/languages/en/src/translations.ts#L22

This closes #326 